### PR TITLE
Add cmakefile ways.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ compiler
 
 # Debug
 debug/
+
+# vscode
+.vscode
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.10)
+project(Compiler LANGUAGES CXX C)
+
+# set the compile standard, with output compile commands.
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall")
+set(CMAKE_EXPORT_COMPILE_COMMANDS true)
+
+# like the makefile, recursively found cpp, cc, c.
+file(GLOB_RECURSE SOURCES
+    "src/*.c"
+    "src/*.cpp"
+    "src/*.cc"
+)
+
+# For each C file, get them compile as c.
+foreach(SOURCE ${SOURCES})
+    if(SOURCE MATCHES "\\.c$")
+        set_source_files_properties(${SOURCE} PROPERTIES LANGUAGE CXX)
+    endif()
+endforeach()
+
+# add executable, the final ./compiler.
+add_executable(compiler ${SOURCES})
+target_include_directories(compiler PUBLIC src)
+
+# The tests make.
+add_custom_target(test
+    COMMAND python3 sp25-tests/test.py "$(shell git branch --show-current)" "${CMAKE_SOURCE_DIR}"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMENT "Running tests..."
+)
+
+# The format check.
+add_custom_target(format
+    COMMAND find src -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.def" \) -exec clang-format -i {} +
+    COMMENT "Formatting source files..."
+)

--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 使用方法：进入根目录，运行make，在根目录下生成可执行文件compiler。
 `./compiler path_to_source_file/source_file.sy path_to_target_file`
 会将对应的sy源文件编译成汇编代码并在目标文件夹下创建.S文件
+
+### Cmake version
+
+run:
+
+```bash
+sh cmake_and_build.sh
+```
+
+You can find the compiler executable file in build.

--- a/cmake_and_build.sh
+++ b/cmake_and_build.sh
@@ -1,0 +1,6 @@
+if [ ! -d './build' ]; then
+    mkdir build
+fi
+cd build
+cmake ..
+make


### PR DESCRIPTION
This is a pull request for using better makefile ways, to avoid from letting compiled files contaminate the src directory.

Cmake方式进行编译，可以避免编译后文件污染src文件夹。生成compile_commands.json可以适用于clangd辅助LSP进行检查。